### PR TITLE
Add missing cyclic quadrilateral in Shortlist 2010 G1

### DIFF
--- a/asy-sources/103-EGMO-1A/4-SL2010-G1.asy
+++ b/asy-sources/103-EGMO-1A/4-SL2010-G1.asy
@@ -51,5 +51,6 @@ label("$Q_2$", Q2, dir(90));
   Item: P1 Q1 C D
   Item: P2 Q2 C D
   Item: P1 Q1 P2 Q2
+  Item: A B Q1 Q2
   Text: IMO Shortlist 2010, Problem G1
 */


### PR DESCRIPTION
Apologies if I'm misunderstanding something, but it seems like A, B, Q1, Q2 should also be an item in the diagram Shortlist 2010 G1. A short proof is that P1, P2, Q1, Q2 are concyclic, so the power of F with respect to this circle is FQ1 * FQ2 = FP1 * FP2, and as P1, P2 are on circle ABCS, this also equals FA * FB. 